### PR TITLE
DST-182: clean up ingestion functions

### DIFF
--- a/02-household-queries/chainlit-household-bot.py
+++ b/02-household-queries/chainlit-household-bot.py
@@ -219,7 +219,9 @@ async def set_embedding():
             model=model_name, google_api_key=GOOGLE_API_KEY
         )
     elif embedding in OPEN_SOURCE_EMBEDDINGS:
-        embedding_function = SentenceTransformerEmbeddings(model_name="all-MiniLM-L6-v2")
+        embedding_function = SentenceTransformerEmbeddings(
+            model_name="all-MiniLM-L6-v2"
+        )
     elif embedding in HUGGING_FACE_EMBEDDINGS:
         model_name = embedding.split("::")[1]
         embedding_function = HuggingFaceEmbeddings(model_name=model_name)

--- a/02-household-queries/eval.py
+++ b/02-household-queries/eval.py
@@ -148,7 +148,11 @@ def get_answer(question, parameters):
         )
 
         ingest_call(
-            vector_db, silent=True, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+            vector_db,
+            embedding_name="all-MiniLM-L6-v2",
+            silent=True,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
         )
         vector_db_chunk_size = parameters["chunk_size"]
 

--- a/02-household-queries/ingest.py
+++ b/02-household-queries/ingest.py
@@ -76,14 +76,8 @@ def get_text_chunks_langchain(
         print("  Split into", len(texts))
     for t in texts:
         token_count = llm.get_num_tokens(t)
-        overlap_and_token = token_count + chunk_overlap
         if token_count > token_limit:
             print(f"Exceeded token limit of {token_limit}: {token_count};")
-        elif chunk_size > (overlap_and_token):
-            print(
-                f"Exceeded token count and overlap {overlap_and_token}: {chunk_size};"
-            )
-        entire_text = source + "\n\n" + text
 
     docs = [
         Document(

--- a/02-household-queries/optimize_encoder.py
+++ b/02-household-queries/optimize_encoder.py
@@ -12,14 +12,6 @@ import spacy
 
 dotenv.load_dotenv()
 
-
-def load_training_json():
-    with open("question_answer_citations.json", encoding="utf-8") as data_file:
-        json_data = json.load(data_file)
-        # print(json.dumps(json_data, indent=2))
-        return json_data
-
-
 def compute_percent_retrieved(retrieved_cards, guru_cards):
     missed_cards = set(guru_cards) - set(retrieved_cards)
     return (len(guru_cards) - len(missed_cards)) / len(guru_cards)

--- a/02-household-queries/optimize_encoder.py
+++ b/02-household-queries/optimize_encoder.py
@@ -1,6 +1,4 @@
-import json
 import dotenv
-from langchain.docstore.document import Document
 import chromadb
 from chromadb.config import Settings
 from dspy_engine import load_training_json

--- a/02-household-queries/optimize_encoder.py
+++ b/02-household-queries/optimize_encoder.py
@@ -1,20 +1,14 @@
-import os
-from bs4 import BeautifulSoup
+import json
 import dotenv
 from langchain.docstore.document import Document
-from langchain_text_splitters import (
-    RecursiveCharacterTextSplitter,
-    NLTKTextSplitter,
-    SpacyTextSplitter,
-)
-import json
 from langchain_community.embeddings import (
     SentenceTransformerEmbeddings,
     HuggingFaceEmbeddings,
 )
 import chromadb
 from chromadb.config import Settings
-from llm import ollama_client
+from dspy_engine import load_training_json
+from ingest import ingest_call
 # from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
 
 from retrieval import create_retriever
@@ -23,10 +17,6 @@ import nltk
 import spacy
 
 dotenv.load_dotenv()
-
-_llm_model_name = os.environ.get("LLM_MODEL_NAME", "mistral")
-
-llm = ollama_client(_llm_model_name, settings={"temperature": 0.1})
 
 EMBEDDINGS = {
     "st_all-MiniLM-L6-v2": {
@@ -67,83 +57,6 @@ def compute_percent_retrieved(retrieved_cards, guru_cards):
 def count_extra_cards(retrieved_cards, guru_cards):
     extra_cards = set(retrieved_cards) - set(guru_cards)
     return len(extra_cards)
-
-
-# split text into chunks
-def get_text_chunks_langchain(
-    text, source, chunk_size, chunk_overlap, token_limit, text_splitter_choice
-):
-    if text_splitter_choice == "2":
-        text_splitter = NLTKTextSplitter()
-    elif text_splitter_choice == "3":
-        text_splitter = SpacyTextSplitter()
-    else:
-        text_splitter = RecursiveCharacterTextSplitter(
-            chunk_size=chunk_size, chunk_overlap=chunk_overlap
-        )
-
-    texts = text_splitter.split_text(source + "\n\n" + text)
-    # print("  Split into", len(texts))
-    for t in texts:
-        token_count = llm.get_num_tokens(t)
-        overlap_and_token = token_count + chunk_overlap
-        if token_count > token_limit:
-            print(f"Exceeded token limit of {token_limit}: {token_count}; {t}")
-        elif chunk_size > (overlap_and_token):
-            print(
-                f"Exceeded token count and overlap {overlap_and_token}: {chunk_size}; {t}"
-            )
-
-    docs = [
-        Document(page_content=t, metadata={"source": source.strip()}) for t in texts
-    ]
-
-    return docs
-
-
-# Chunk the json data and load into vector db
-def add_json_html_data_to_vector_db(
-    vectordb,
-    file_path,
-    content_key,
-    index_key,
-    chunk_size,
-    chunk_overlap,
-    token_limit,
-    text_splitter_choice,
-):
-    data_file = open(file_path, encoding="utf-8")
-    json_data = json.load(data_file)
-    for content in json_data:
-        if not content[index_key].strip().endswith("?"):
-            continue
-        soup = BeautifulSoup(content[content_key], "html.parser")
-        text = soup.get_text(separator="\n", strip=True)
-        # print("Processing document:", content[index_key])
-        chunks = get_text_chunks_langchain(
-            text,
-            content[index_key],
-            chunk_size=chunk_size,
-            chunk_overlap=chunk_overlap,
-            token_limit=token_limit,
-            text_splitter_choice=text_splitter_choice,
-        )
-        vectordb.add_documents(documents=chunks)
-
-
-def ingest_call(vectordb, chunk_size, chunk_overlap, token_limit, text_splitter_choice):
-    # download from https://drive.google.com/drive/folders/1DkAQ03bBVIPoO1d8gcHVnilQ-9VXfhJ8?usp=drive_link
-    guru_file_path = "./guru_cards_for_nava.json"
-    add_json_html_data_to_vector_db(
-        vectordb=vectordb,
-        file_path=guru_file_path,
-        content_key="content",
-        index_key="preferredPhrase",
-        chunk_size=chunk_size,
-        chunk_overlap=chunk_overlap,
-        token_limit=token_limit,
-        text_splitter_choice=text_splitter_choice,
-    )
 
 
 def evaluate_retrieval(vectordb):
@@ -209,6 +122,7 @@ def run_embedding_func_and_eval_retrieval(
         chunk_overlap=chunk_overlap,
         token_limit=embeddings["token_limit"],
         text_splitter_choice=text_splitter_choice,
+        silent=True,
     )
     recall_results = evaluate_retrieval(vectordb)
     persistent_client.reset()

--- a/02-household-queries/optimize_encoder.py
+++ b/02-household-queries/optimize_encoder.py
@@ -1,45 +1,16 @@
 import json
 import dotenv
 from langchain.docstore.document import Document
-from langchain_community.embeddings import (
-    SentenceTransformerEmbeddings,
-    HuggingFaceEmbeddings,
-)
 import chromadb
 from chromadb.config import Settings
 from dspy_engine import load_training_json
-from ingest import ingest_call
-# from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
-
+from ingest import EMBEDDINGS, ingest_call
 from retrieval import create_retriever
 from langchain_community.vectorstores import Chroma
 import nltk
 import spacy
 
 dotenv.load_dotenv()
-
-EMBEDDINGS = {
-    "st_all-MiniLM-L6-v2": {
-        "func": SentenceTransformerEmbeddings(model_name="all-MiniLM-L6-v2"),
-        "token_limit": 256,
-    },
-    "hf_all-MiniLM-L6-v2": {
-        "func": HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2"),
-        "token_limit": 256,
-    },
-    #  "google_models/embedding-001": {"func": GoogleGenerativeAIEmbeddings(model="models/embedding-001"), "token_limit":2048},
-    #  "google_models/text-embedding-004": {"func": GoogleGenerativeAIEmbeddings(model="models/text-embedding-004"), "token_limit":768},
-    "BAAI/bge-small-en-v1.5": {
-        "func": SentenceTransformerEmbeddings(model_name="BAAI/bge-small-en-v1.5"),
-        "token_limit": 512,
-    },
-    "mixedbread-ai/mxbai-embed-large-v1": {
-        "func": SentenceTransformerEmbeddings(
-            model_name="mixedbread-ai/mxbai-embed-large-v1"
-        ),
-        "token_limit": 1024,
-    },
-}
 
 
 def load_training_json():
@@ -103,7 +74,7 @@ def print_and_set_recall_stats(results):
 
 
 def run_embedding_func_and_eval_retrieval(
-    embeddings, chunk_size, chunk_overlap, text_splitter_choice
+    embedding_name, embeddings, chunk_size, chunk_overlap, text_splitter_choice
 ):
     selected_embedding = embeddings["func"]
     persistent_client = chromadb.PersistentClient(
@@ -120,6 +91,7 @@ def run_embedding_func_and_eval_retrieval(
         vectordb=vectordb,
         chunk_size=chunk_size,
         chunk_overlap=chunk_overlap,
+        embedding_name=embedding_name,
         token_limit=embeddings["token_limit"],
         text_splitter_choice=text_splitter_choice,
         silent=True,
@@ -156,6 +128,7 @@ overall_results = []
 for embedding in EMBEDDINGS:
     print("Embedding: " + embedding)
     results = run_embedding_func_and_eval_retrieval(
+        embedding,
         EMBEDDINGS[embedding],
         chunk_size=chunk_size,
         chunk_overlap=chunk_overlap,

--- a/02-household-queries/optimize_encoder.py
+++ b/02-household-queries/optimize_encoder.py
@@ -10,6 +10,7 @@ import spacy
 
 dotenv.load_dotenv()
 
+
 def compute_percent_retrieved(retrieved_cards, guru_cards):
     missed_cards = set(guru_cards) - set(retrieved_cards)
     return (len(guru_cards) - len(missed_cards)) / len(guru_cards)


### PR DESCRIPTION
## Ticket

Resolves DST-182
by comparing the chunk size / overlap with the embedding function supplied to the vectordb argument and raise a warning there if they don't match

## Changes
- updated `ingest.py` file with code from `optimize_encoder.py`
- added defaults for tools

## Testing Tools

Testing instructions and expected behavior:
- household eligibility bot
1. run ./chainlit-household-bot.py 
2. select all-MiniLM-L6-v2 (the hugging face embedding fn seems to be broken, unrelated to this PR)for embedding option and other llm besides google
3. upload a pdf and/or json data
4. ingestion should succeeed
5. delete chromadb/

Note `python run.py` already has `print(f"Max sequence length (max tokens):` so we're not passing the embedding info
1. run python run.py
2. select any llm
3. select any option with ingestion

- run python optimize_encoder.py
- run python eval.py
