### PR TITLE
github action: Push image to ECR

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -31,12 +31,11 @@ on:
         type: boolean
         default: 'false'
 
-# env:
-  # Target path where the image will be pushed, i.e., to GHCR for the current repo
-  # GHCR_PATH: "ghcr.io/${{ github.repository }}/${{ inputs.image_name }}"
-
 jobs:
   publish-image:
+    env:
+      # Target path where the image will be pushed, i.e., to GHCR for the current repo
+      GHCR_PATH: "ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }}"
     runs-on: ubuntu-latest
     steps:
     - name: Configure AWS credentials
@@ -59,18 +58,35 @@ jobs:
       if: inputs.build_image
       uses: actions/checkout@v4
 
+    # Improve building performance by pulling image from GHCR, if it exists
+    # https://stackoverflow.com/questions/77494739/github-action-gha-docker-cache-much-slower-than-recreating-the-image
+    - name: "Login to GHCR (GitHub Container Registry) for caching image"
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: "Pull cached image"
+      if: inputs.build_image
+      run: |
+        { docker pull "$GHCR_PATH" && docker tag "$GHCR_PATH" ${{ inputs.image_name }}:${{ inputs.image_tag }}
+        } || exit 0
+
     - name: "Build image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
       if: inputs.build_image
-      shell: bash
-      env:
-          ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
       run: |
         cd ${{ inputs.dockerfile_folder }}
         docker build -t "${{ inputs.image_name }}:${{ inputs.image_tag }}" .
 
+    - name: "Cache image in GHCR for future runs"
+      if: inputs.build_image
+      run: |
+        # echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        docker tag ${{ inputs.image_name }}:${{ inputs.image_tag }} "$GHCR_PATH"
+        docker push "$GHCR_PATH"
+
     - name: "Publish image to AWS ECR'"
       if: inputs.build_image
-      shell: bash
       env:
           ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
       run: |
@@ -81,7 +97,6 @@ jobs:
 
     - name: "Update AWS Service"
       if: inputs.deploy_image
-      shell: bash
       env:
         CLUSTER_NAME: genai-experiments
         SERVICE_NAME: ${{ inputs.image_name }}-service

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -25,8 +25,6 @@ on:
         default: '0.01'
 
 env:
-  # Add prefix to be clear that we're not using the original image
-  TARGET_IMAGE: "${{ inputs.image_name }}"
   # Target path where the image will be pushed, i.e., to GHCR for the current repo
   # GHCR_PATH: "ghcr.io/${{ github.repository }}/${{ inputs.image_name }}"
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -12,14 +12,17 @@ on:
         description: 'Folder containing Dockerfile to build'
         required: true
         type: string
+        default: '02-household-queries'
       image_name:
         description: 'Name of the image to push'
         required: true
         type: string
+        default: 'chainlit_bot'
       image_tag:
         description: 'Tag/Version of the image to push'
         required: true
         type: string
+        default: '0.01'
 
 env:
   # Add prefix to be clear that we're not using the original image
@@ -29,9 +32,11 @@ env:
 
 jobs:
   publish-image:
-    if: github.repository == 'navapbc/labs-gen-ai-experiments'
     runs-on: ubuntu-latest
     steps:
+    - name: "Checkout source code"
+      uses: actions/checkout@v4
+
     - name: "Login to GitHub Container Registry"
       uses: docker/login-action@v3.0.0
       with:
@@ -43,8 +48,9 @@ jobs:
       id: docker-push
       shell: bash
       run: |
+        ls
         cd ${{ inputs.dockerfile_folder }}
-        docker build -t "${{ inputs.image_name }}:${{ inputs.image_tag }}"
+        docker build -t "${{ inputs.image_name }}:${{ inputs.image_tag }}" .
 
         echo "# Publishing image ${{ inputs.image_name }}:${{ inputs.image_tag }} to ${{ env.GHCR_PATH }}"
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -40,6 +40,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         mask-aws-account-id: true
       # TODO: secure credentials: https://github.com/aws-actions/amazon-ecr-login?tab=readme-ov-file#ecr-private
+      # https://github.com/docker/login-action?tab=readme-ov-file#aws-elastic-container-registry-ecr
 
     - name: Login to Amazon ECR
       id: login-ecr
@@ -50,22 +51,27 @@ jobs:
     - name: "Checkout source code"
       uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx
+    - name: Set up Docker Buildx for build-push-action
       uses: docker/setup-buildx-action@v3
       # with:
       #   version: latest
       #   driver-opts: image=moby/buildkit:latest
 
-    - name: Build Tag and Push Docker image
+    - name: Login to Docker Hub for build-push-action
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and Push Docker image
       uses: docker/build-push-action@v5
       env:
         ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
       with:
-        file: ${{ inputs.dockerfile_folder }}/Dockerfile
         context: ${{ inputs.dockerfile_folder }}
         tags: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         push: true
-        pull: true
+        # pull: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
         # cache-from: type=registry,ref=${{ env.ECR_PATH }}:dockercache

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,9 +1,5 @@
-name: "Build and publish Docker image"
+name: "Build and push Docker image"
 run-name: "Publish image: ${{inputs.image_name}} ${{inputs.image_tag}}"
-
-# SecRel will not sign images outside the scope of the repository that's calling SecRel,
-# so the image must exist in abd-vro-internal for SecRel to sign the images (required for sandbox and prod environments).
-# Run this in action in both abd-vro and abd-vro-internal repos.
 
 on:
   workflow_dispatch:
@@ -14,15 +10,26 @@ on:
         type: string
         default: '02-household-queries'
       image_name:
-        description: 'Name of the image to push'
+        description: 'Name of the image and prefix of service'
         required: true
-        type: string
-        default: 'chainlit_bot'
+        type: choice
+        options:
+        - 'chainlit-chatbot'
       image_tag:
         description: 'Tag/Version of the image to push'
         required: true
         type: string
         default: '0.01'
+      build_image:
+        description: "Build and push image"
+        required: true
+        type: boolean
+        default: 'true'
+      deploy_image:
+        description: "Deploy image"
+        required: true
+        type: boolean
+        default: 'false'
 
 # env:
   # Target path where the image will be pushed, i.e., to GHCR for the current repo
@@ -49,24 +56,29 @@ jobs:
         mask-password: true
 
     - name: "Checkout source code"
+      if: inputs.build_image
       uses: actions/checkout@v4
 
     - name: Set up Docker Buildx for build-push-action
+      if: inputs.build_image
       uses: docker/setup-buildx-action@v3
       # with:
       #   version: latest
       #   driver-opts: image=moby/buildkit:latest
 
-    - name: Login to Docker Hub for build-push-action
+    - name: "Login to Docker Hub for build-push-action"
+      if: inputs.build_image
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and Push Docker image
+    - name: "Build Docker image"
+      id: build
+      if: inputs.build_image
       uses: docker/build-push-action@v5
-      env:
-        ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
+      # env:
+      #   ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
       with:
         context: ${{ inputs.dockerfile_folder }}
         tags: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
@@ -77,7 +89,7 @@ jobs:
         # cache-to: type=registry,ref=${{ env.ECR_PATH }}:dockercache,mode=max,image-manifest=true
 
     - name: "Publish image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
-      id: docker-push
+      if: inputs.build_image
       shell: bash
       env:
           ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
@@ -87,3 +99,11 @@ jobs:
         docker tag "${{ inputs.image_name }}:${{ inputs.image_tag }}" "$ECR_PATH:${{ inputs.image_tag }}"
         docker push "$ECR_PATH:${{ inputs.image_tag }}"
 
+    - name: "Update AWS Service"
+      if: inputs.deploy_image
+      shell: bash
+      env:
+        CLUSTER_NAME: genai-experiments
+        SERVICE_NAME: ${{ inputs.image_name }}-service
+      run: |
+        aws ecs update-service --force-new-deployment --cluster "$CLUSTER_NAME" --service "$SERVICE_NAME"

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -70,6 +70,7 @@ jobs:
       with:
         context: ${{ inputs.dockerfile_folder }}
         tags: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
+        load: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
         # cache-from: type=registry,ref=${{ env.ECR_PATH }}:dockercache

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -44,14 +44,16 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: "Publish images using tags '${{ inputs.image_tag }}'"
-      id: docker-push
+    - name: "Build image in ${{ inputs.dockerfile_folder }} with tag '${{ inputs.image_tag }}'"
       shell: bash
       run: |
-        ls
         cd ${{ inputs.dockerfile_folder }}
         docker build -t "${{ inputs.image_name }}:${{ inputs.image_tag }}" .
 
+    - name: "Publish image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
+      id: docker-push
+      shell: bash
+      run: |
         echo "# Publishing image ${{ inputs.image_name }}:${{ inputs.image_tag }} to ${{ env.GHCR_PATH }}"
 
         docker tag "${{ inputs.image_name }}:${{ inputs.image_tag }}" "${{ env.GHCR_PATH }}:${{ inputs.image_tag }}"

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -50,17 +50,32 @@ jobs:
     - name: "Checkout source code"
       uses: actions/checkout@v4
 
-    - name: "Build image in ${{ inputs.dockerfile_folder }} with tag '${{ inputs.image_tag }}'"
-      shell: bash
-      run: |
-        cd ${{ inputs.dockerfile_folder }}
-        docker build -t "${{ inputs.image_name }}:${{ inputs.image_tag }}" .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      # with:
+      #   version: latest
+      #   driver-opts: image=moby/buildkit:latest
+
+    - name: Build Tag and Push Docker image
+      uses: docker/build-push-action@v5
+      env:
+        ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
+      with:
+        file: ${{ inputs.dockerfile_folder }}/Dockerfile
+        context: ${{ inputs.dockerfile_folder }}
+        tags: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
+        push: true
+        pull: true
+        # cache-from: type=gha
+        # cache-to: type=gha,mode=max
+        cache-from: type=registry,ref=${{ env.ECR_PATH }}:dockercache
+        cache-to: type=registry,ref=${{ env.ECR_PATH }}:dockercache,mode=max,image-manifest=true
 
     - name: "Publish image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
       id: docker-push
-      env:
-        ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
       shell: bash
+      env:
+          ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
       run: |
         echo "# Publishing image ${{ inputs.image_name }}:${{ inputs.image_tag }} to $ECR_PATH"
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -24,7 +24,7 @@ on:
         type: string
         default: '0.01'
 
-env:
+# env:
   # Target path where the image will be pushed, i.e., to GHCR for the current repo
   # GHCR_PATH: "ghcr.io/${{ github.repository }}/${{ inputs.image_name }}"
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -35,15 +35,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
+        aws-region: us-east-1
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+        mask-aws-account-id: true
+      # TODO: secure credentials: https://github.com/aws-actions/amazon-ecr-login?tab=readme-ov-file#ecr-private
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
       with:
         mask-password: true
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.MY_GITHUB_TOKEN }}
 
     - name: "Build image in ${{ inputs.dockerfile_folder }} with tag '${{ inputs.image_tag }}'"
       shell: bash

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -70,8 +70,6 @@ jobs:
       with:
         context: ${{ inputs.dockerfile_folder }}
         tags: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
-        push: true
-        # pull: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
         # cache-from: type=registry,ref=${{ env.ECR_PATH }}:dockercache

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -58,32 +58,11 @@ jobs:
       if: inputs.build_image
       uses: actions/checkout@v4
 
-    # Improve building performance by pulling image from GHCR, if it exists
-    # https://stackoverflow.com/questions/77494739/github-action-gha-docker-cache-much-slower-than-recreating-the-image
-    - name: "Login to GHCR (GitHub Container Registry) for caching image"
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: "Pull cached image"
-      if: inputs.build_image
-      run: |
-        { docker pull "$GHCR_PATH" && docker tag "$GHCR_PATH" ${{ inputs.image_name }}:${{ inputs.image_tag }}
-        } || exit 0
-
     - name: "Build image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
       if: inputs.build_image
       run: |
         cd ${{ inputs.dockerfile_folder }}
         docker build -t "${{ inputs.image_name }}:${{ inputs.image_tag }}" .
-
-    - name: "Cache image in GHCR for future runs"
-      if: inputs.build_image
-      run: |
-        # echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-        docker tag ${{ inputs.image_name }}:${{ inputs.image_tag }} "$GHCR_PATH"
-        docker push "$GHCR_PATH"
 
     - name: "Publish image to AWS ECR'"
       if: inputs.build_image

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -41,7 +41,7 @@ jobs:
       uses: docker/login-action@v3.0.0
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
+        username: yoomlam
         password: ${{ secrets.MY_GITHUB_TOKEN }}
 
     - name: "Build image in ${{ inputs.dockerfile_folder }} with tag '${{ inputs.image_tag }}'"

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -66,10 +66,10 @@ jobs:
         tags: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         push: true
         pull: true
-        # cache-from: type=gha
-        # cache-to: type=gha,mode=max
-        cache-from: type=registry,ref=${{ env.ECR_PATH }}:dockercache
-        cache-to: type=registry,ref=${{ env.ECR_PATH }}:dockercache,mode=max,image-manifest=true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        # cache-from: type=registry,ref=${{ env.ECR_PATH }}:dockercache
+        # cache-to: type=registry,ref=${{ env.ECR_PATH }}:dockercache,mode=max,image-manifest=true
 
     - name: "Publish image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
       id: docker-push

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -28,21 +28,27 @@ env:
   # Add prefix to be clear that we're not using the original image
   TARGET_IMAGE: "${{ inputs.image_name }}"
   # Target path where the image will be pushed, i.e., to GHCR for the current repo
-  GHCR_PATH: "ghcr.io/${{ github.repository }}/${{ inputs.image_name }}"
+  # GHCR_PATH: "ghcr.io/${{ github.repository }}/${{ inputs.image_name }}"
 
 jobs:
   publish-image:
     runs-on: ubuntu-latest
     steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+      with:
+        mask-password: true
+
     - name: "Checkout source code"
       uses: actions/checkout@v4
-
-    - name: "Login to GitHub Container Registry"
-      uses: docker/login-action@v3.0.0
-      with:
-        registry: ghcr.io
-        username: yoomlam
-        password: ${{ secrets.MY_GITHUB_TOKEN }}
 
     - name: "Build image in ${{ inputs.dockerfile_folder }} with tag '${{ inputs.image_tag }}'"
       shell: bash
@@ -52,10 +58,12 @@ jobs:
 
     - name: "Publish image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
       id: docker-push
+      env:
+        ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
       shell: bash
       run: |
-        echo "# Publishing image ${{ inputs.image_name }}:${{ inputs.image_tag }} to ${{ env.GHCR_PATH }}"
+        echo "# Publishing image ${{ inputs.image_name }}:${{ inputs.image_tag }} to $ECR_PATH"
 
-        docker tag "${{ inputs.image_name }}:${{ inputs.image_tag }}" "${{ env.GHCR_PATH }}:${{ inputs.image_tag }}"
-        docker push "${{ env.GHCR_PATH }}:${{ inputs.image_tag }}"
+        docker tag "${{ inputs.image_name }}:${{ inputs.image_tag }}" "$ECR_PATH:${{ inputs.image_tag }}"
+        docker push "$ECR_PATH:${{ inputs.image_tag }}"
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -59,36 +59,16 @@ jobs:
       if: inputs.build_image
       uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx for build-push-action
+    - name: "Build image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
       if: inputs.build_image
-      uses: docker/setup-buildx-action@v3
-      # with:
-      #   version: latest
-      #   driver-opts: image=moby/buildkit:latest
+      shell: bash
+      env:
+          ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
+      run: |
+        cd ${{ inputs.dockerfile_folder }}
+        docker build -t "${{ inputs.image_name }}:${{ inputs.image_tag }}" .
 
-    - name: "Login to Docker Hub for build-push-action"
-      if: inputs.build_image
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: "Build Docker image"
-      id: build
-      if: inputs.build_image
-      uses: docker/build-push-action@v5
-      # env:
-      #   ECR_PATH: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPO }}
-      with:
-        context: ${{ inputs.dockerfile_folder }}
-        tags: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
-        load: true
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        # cache-from: type=registry,ref=${{ env.ECR_PATH }}:dockercache
-        # cache-to: type=registry,ref=${{ env.ECR_PATH }}:dockercache,mode=max,image-manifest=true
-
-    - name: "Publish image ${{ inputs.image_name }} with tag '${{ inputs.image_tag }}'"
+    - name: "Publish image to AWS ECR'"
       if: inputs.build_image
       shell: bash
       env:

--- a/02-household-queries/Dockerfile
+++ b/02-household-queries/Dockerfile
@@ -15,7 +15,9 @@ RUN pip3 install -r requirements.txt
 
 COPY . .
 
-# LABEL org.opencontainers.image.source https://github.com/navapbc/labs-gen-ai-experiments
+# Associate GHCR package with GitHub repo; otherwise, it's associated with the navapbc GitHub organization
+# See https://github.com/orgs/navapbc/packages?repo_name=labs-gen-ai-experiments
+LABEL org.opencontainers.image.source https://github.com/navapbc/labs-gen-ai-experiments
 
 EXPOSE 8000
 HEALTHCHECK CMD curl http://localhost:8000 || exit 1

--- a/02-household-queries/Dockerfile
+++ b/02-household-queries/Dockerfile
@@ -16,7 +16,5 @@ RUN pip3 install -r requirements.txt
 # LABEL org.opencontainers.image.source https://github.com/navapbc/labs-gen-ai-experiments
 
 EXPOSE 8000
-
-# HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
-
+HEALTHCHECK CMD curl http://localhost:8000 || exit 1
 ENTRYPOINT ["chainlit", "run", "--port", "8000", "-h", "chainlit-household-bot.py"]

--- a/02-household-queries/Dockerfile
+++ b/02-household-queries/Dockerfile
@@ -13,6 +13,8 @@ RUN git clone https://github.com/navapbc/labs-gen-ai-experiments.git .
 WORKDIR /app/02-household-queries
 RUN pip3 install -r requirements.txt
 
+COPY . .
+
 # LABEL org.opencontainers.image.source https://github.com/navapbc/labs-gen-ai-experiments
 
 EXPOSE 8000

--- a/02-household-queries/Dockerfile
+++ b/02-household-queries/Dockerfile
@@ -2,22 +2,19 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    software-properties-common \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://github.com/navapbc/labs-gen-ai-experiments.git .
-WORKDIR /app/02-household-queries
-RUN pip3 install -r requirements.txt
+# RUN apt-get update && apt-get install -y \
+#     build-essential \
+#     curl \
+#     software-properties-common \
+#     git \
+#     && rm -rf /var/lib/apt/lists/*
 
 COPY . .
+RUN pip3 install -r requirements.txt
 
 # Associate GHCR package with GitHub repo; otherwise, it's associated with the navapbc GitHub organization
 # See https://github.com/orgs/navapbc/packages?repo_name=labs-gen-ai-experiments
-LABEL org.opencontainers.image.source https://github.com/navapbc/labs-gen-ai-experiments
+# LABEL org.opencontainers.image.source https://github.com/navapbc/labs-gen-ai-experiments
 
 EXPOSE 8000
 HEALTHCHECK CMD curl http://localhost:8000 || exit 1

--- a/02-household-queries/Dockerfile
+++ b/02-household-queries/Dockerfile
@@ -13,16 +13,10 @@ RUN git clone https://github.com/navapbc/labs-gen-ai-experiments.git .
 WORKDIR /app/02-household-queries
 RUN pip3 install -r requirements.txt
 
-LABEL org.opencontainers.image.source=https://github.com/navapbc/labs-gen-ai-experiments
-
-# Update files based on current folder
-COPY . .
+# LABEL org.opencontainers.image.source https://github.com/navapbc/labs-gen-ai-experiments
 
 EXPOSE 8000
 
 # HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
 ENTRYPOINT ["chainlit", "run", "--port", "8000", "-h", "chainlit-household-bot.py"]
-
-# docker build -t chainlit1 .
-# docker run --rm -p 8000:8000 chainlit1

--- a/02-household-queries/chainlit-household-bot.py
+++ b/02-household-queries/chainlit-household-bot.py
@@ -23,7 +23,7 @@ from langchain_google_genai import GoogleGenerativeAIEmbeddings
 import os
 
 from ingest import (
-    EMBEDDINGS,
+    get_embeddings,
     add_json_html_data_to_vector_db,
     add_pdf_to_vector_db,
     ingest_call,
@@ -353,7 +353,7 @@ async def on_click_upload_file_query(action: cl.Action):
             add_json_html_data_to_vector_db(
                 vectordb=vectordb,
                 embedding_name=embedding,
-                token_limit=EMBEDDINGS[embedding]["token_limit"],
+                token_limit=get_embeddings()[embedding]["token_limit"],
                 file_path=file.path,
                 content_key="content",
                 index_key="preferredPhrase",


### PR DESCRIPTION
## Ticket

Partly addresses https://navalabs.atlassian.net/browse/DST-216

## Changes

Adds a "Build and push Docker image" GitHub Action workflow that pushes to AWS ECR for deployment.
The workflow is run manually by going to the [Actions tab](https://github.com/navapbc/labs-gen-ai-experiments/actions/workflows/push-image.yml) and clicking "Run workflow".

## Context for reviewers

Need a user-friendly mechanism to deploy a Docker container so that BDT users have access to a web chatbot running in the container.

