### PR TITLE
feat: Add summarizing and quoting capabilities to 05-assistive-chatbot

### DIFF
--- a/05-assistive-chatbot/chatbot-chainlit.py
+++ b/05-assistive-chatbot/chatbot-chainlit.py
@@ -158,6 +158,8 @@ def format_v2_results_as_markdown(gen_results):
     return {
         "content": "\n".join(resp + dq_resp + cards_resp),
         "elements": [
+            # Example of how to use cl.Text with different display parameters -- it's not intuitive
+            # The name argument must exist in the message content so that a link can be created.
             # cl.Text(name="Derived Questions", content="\n".join(dq_resp), display="side"),
             # cl.Text(name="Guru Cards", content="\n".join(cards_resp), display="inline")
         ],

--- a/05-assistive-chatbot/chatbot-chainlit.py
+++ b/05-assistive-chatbot/chatbot-chainlit.py
@@ -42,13 +42,13 @@ async def init_chat():
             ),
             Select(
                 id="model",
-                label="LLM Model",
+                label="Primary LLM Model",
                 values=llms.available_llms(),
                 initial_value=chatbot.initial_settings["model"],
             ),
             Slider(
                 id="temperature",
-                label="LLM Temperature",
+                label="Temperature for primary LLM",
                 initial=chatbot.initial_settings["temperature"],
                 min=0,
                 max=2,
@@ -61,6 +61,20 @@ async def init_chat():
                 min=1,
                 max=10,
                 step=1,
+            ),
+            Select(
+                id="model2",
+                label="LLM Model for summarizer",
+                values=llms.available_llms(),
+                initial_value=chatbot.initial_settings["model2"],
+            ),
+            Slider(
+                id="temperature2",
+                label="Temperature for summarizer",
+                initial=chatbot.initial_settings["temperature2"],
+                min=0,
+                max=2,
+                step=0.1,
             ),
             # TODO: Add LLM response streaming capability
             # Switch(id="streaming", label="Stream response tokens", initial=True),
@@ -83,7 +97,7 @@ async def update_settings(settings):
 @utils.timer
 async def apply_settings():
     settings = cl.user_session.get("settings")
-    await create_llm_client(settings)
+    await create_chat_engine(settings)
 
     # PLACEHOLDER: Apply other settings
 
@@ -95,11 +109,11 @@ async def apply_settings():
     return settings
 
 
-async def create_llm_client(settings):
-    msg = cl.Message(author="backend", content=f"Setting up LLM: {settings['model']} ...\n")
+async def create_chat_engine(settings):
+    msg = cl.Message(author="backend", content=f"Setting up chat engine: {settings['chat_engine']} ...\n")
 
     cl.user_session.set("chat_engine", chatbot.create_chat_engine(settings))
-    await msg.stream_token("Done setting up LLM")
+    await msg.stream_token("Done setting up chat engine")
     await msg.send()
 
 

--- a/05-assistive-chatbot/chatbot/__init__.py
+++ b/05-assistive-chatbot/chatbot/__init__.py
@@ -75,7 +75,7 @@ def validate_settings(settings):
         if model_name not in llms._discover_llms():
             return f"Unknown {setting_name}: '{model_name}'"
 
-        if chat_engine.startswith("Summaries") and not model_name.contains("instruct"):
+        if chat_engine.startswith("Summaries") and "instruct" not in model_name:
             logger.warning("For the %s chat engine, an `*instruct` model is recommended", chat_engine)
 
     # PLACEHOLDER: Validate other settings

--- a/05-assistive-chatbot/chatbot/__init__.py
+++ b/05-assistive-chatbot/chatbot/__init__.py
@@ -30,14 +30,22 @@ logger = logging.getLogger(__name__)
 
 ## Initialize settings
 
+# Opt out of telemetry -- https://docs.trychroma.com/telemetry
+os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
+
+# Used by SentenceTransformerEmbeddings and HuggingFaceEmbeddings
+os.environ.setdefault("SENTENCE_TRANSFORMERS_HOME", "./.sentence-transformers-cache")
+
 
 @utils.verbose_timer(logger)
 def _init_settings():
+    # Remember to update ChatSettings in chatbot-chainlit.py when adding new settings
     return {
         "enable_api": is_true(os.environ.get("ENABLE_CHATBOT_API", "False")),
         "chat_engine": os.environ.get("CHAT_ENGINE", "Direct"),
         "model": os.environ.get("LLM_MODEL_NAME", "mock :: llm"),
         "temperature": float(os.environ.get("LLM_TEMPERATURE", 0.1)),
+        "retrieve_k": int(os.environ.get("RETRIEVE_K", 4)),
     }
 
 

--- a/05-assistive-chatbot/chatbot/__init__.py
+++ b/05-assistive-chatbot/chatbot/__init__.py
@@ -68,4 +68,4 @@ def validate_settings(settings):
 
 @utils.timer
 def create_chat_engine(settings):
-    return engines.create(settings["chat_engine"], settings)
+    return engines.create_engine(settings["chat_engine"], settings)

--- a/05-assistive-chatbot/chatbot/__init__.py
+++ b/05-assistive-chatbot/chatbot/__init__.py
@@ -53,6 +53,7 @@ def _init_settings():
         "retrieve_k": int(os.environ.get("RETRIEVE_K", 4)),
         # Used by SummariesChatEngine
         "model2": os.environ.get("LLM_MODEL_NAME_2", os.environ.get("LLM_MODEL_NAME", "mock :: llm")),
+        "temperature2": float(os.environ.get("LLM_TEMPERATURE2", 0.1)),
     }
 
 
@@ -69,9 +70,13 @@ def validate_settings(settings):
     if chat_engine not in engines._discover_chat_engines():
         return f"Unknown chat_engine: '{chat_engine}'"
 
-    model_name = settings["model"]
-    if model_name not in llms._discover_llms():
-        return f"Unknown model: '{model_name}'"
+    for setting_name in ["model", "model2"]:
+        model_name = settings[setting_name]
+        if model_name not in llms._discover_llms():
+            return f"Unknown {setting_name}: '{model_name}'"
+
+        if chat_engine.startswith("Summaries") and not model_name.contains("instruct"):
+            logger.warning("For the %s chat engine, an `*instruct` model is recommended", chat_engine)
 
     # PLACEHOLDER: Validate other settings
 

--- a/05-assistive-chatbot/chatbot/__init__.py
+++ b/05-assistive-chatbot/chatbot/__init__.py
@@ -37,18 +37,22 @@ os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
 os.environ.setdefault("SENTENCE_TRANSFORMERS_HOME", "./.sentence-transformers-cache")
 
 # Disable DSPy cache to get different responses for retry attempts
+# Set to true to enable caching for faster responses and optimizing prompts using DSPy
 os.environ.setdefault("DSP_CACHEBOOL", "false")
 
 
 @utils.verbose_timer(logger)
 def _init_settings():
     # Remember to update ChatSettings in chatbot-chainlit.py when adding new settings
+    # and update chatbot/engines/__init.py:CHATBOT_SETTING_KEYS
     return {
         "enable_api": is_true(os.environ.get("ENABLE_CHATBOT_API", "False")),
         "chat_engine": os.environ.get("CHAT_ENGINE", "Direct"),
         "model": os.environ.get("LLM_MODEL_NAME", "mock :: llm"),
         "temperature": float(os.environ.get("LLM_TEMPERATURE", 0.1)),
         "retrieve_k": int(os.environ.get("RETRIEVE_K", 4)),
+        # Used by SummariesChatEngine
+        "model2": os.environ.get("LLM_MODEL_NAME_2", os.environ.get("LLM_MODEL_NAME", "mock :: llm")),
     }
 
 

--- a/05-assistive-chatbot/chatbot/__init__.py
+++ b/05-assistive-chatbot/chatbot/__init__.py
@@ -36,6 +36,9 @@ os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
 # Used by SentenceTransformerEmbeddings and HuggingFaceEmbeddings
 os.environ.setdefault("SENTENCE_TRANSFORMERS_HOME", "./.sentence-transformers-cache")
 
+# Disable DSPy cache to get different responses for retry attempts
+os.environ.setdefault("DSP_CACHEBOOL", "false")
+
 
 @utils.verbose_timer(logger)
 def _init_settings():

--- a/05-assistive-chatbot/chatbot/engines/__init__.py
+++ b/05-assistive-chatbot/chatbot/engines/__init__.py
@@ -43,13 +43,12 @@ def create_engine(engine_name, settings=None):
 ## Utility functions
 
 # Settings that are specific to our chatbot and shouldn't be passed onto the LLM client
-CHATBOT_SETTING_KEYS = ["enable_api", "chat_engine", "model", "model2"]
+CHATBOT_SETTING_KEYS = ["enable_api", "chat_engine", "model", "model2", "temperature2", "retrieve_k"]
 
 
 @utils.timer
 def create_llm_client(settings):
     llm_name = settings["model"]
-    # llm_settings = dict((k, settings[k]) for k in ["temperature"] if k in settings)
     remaining_settings = {k: settings[k] for k in settings if k not in CHATBOT_SETTING_KEYS}
     client = llms.init_client(llm_name, remaining_settings)
     return client

--- a/05-assistive-chatbot/chatbot/engines/__init__.py
+++ b/05-assistive-chatbot/chatbot/engines/__init__.py
@@ -45,7 +45,7 @@ def create_engine(engine_name, settings=None):
 ## Utility functions
 
 # Settings that are specific to our chatbot and shouldn't be passed onto the LLM client
-CHATBOT_SETTING_KEYS = ["enable_api", "chat_engine", "model", "model2", "temperature2", "retrieve_k"]
+CHATBOT_SETTING_KEYS = ["env", "enable_api", "chat_engine", "model", "model2", "temperature2", "retrieve_k"]
 
 
 @utils.timer

--- a/05-assistive-chatbot/chatbot/engines/__init__.py
+++ b/05-assistive-chatbot/chatbot/engines/__init__.py
@@ -35,7 +35,7 @@ def _discover_chat_engines(force=False):
 
 
 @utils.timer
-def create(engine_name, settings=None):
+def create_engine(engine_name, settings=None):
     _discover_chat_engines()
     return _engines[engine_name].init_engine(settings)
 

--- a/05-assistive-chatbot/chatbot/engines/__init__.py
+++ b/05-assistive-chatbot/chatbot/engines/__init__.py
@@ -42,7 +42,8 @@ def create_engine(engine_name, settings=None):
 
 ## Utility functions
 
-CHATBOT_SETTING_KEYS = ["enable_api", "chat_engine", "model"]
+# Settings that are specific to our chatbot and shouldn't be passed onto the LLM client
+CHATBOT_SETTING_KEYS = ["enable_api", "chat_engine", "model", "model2"]
 
 
 @utils.timer

--- a/05-assistive-chatbot/chatbot/engines/v2_household_dspy_engine.py
+++ b/05-assistive-chatbot/chatbot/engines/v2_household_dspy_engine.py
@@ -1,0 +1,175 @@
+import json
+import logging
+import os
+from functools import cached_property
+
+import dspy  # type: ignore[import-untyped]
+from dspy.signatures.signature import signature_to_template  # type: ignore[import-untyped]
+
+from chatbot import engines, guru_cards, utils, vector_db
+from chatbot.engines.v2_household_engine import GenerationResults, collect_retrieved_cards, populate_summaries
+
+logger = logging.getLogger(__name__)
+
+ENGINE_NAME = "Summaries-DSPy"
+
+
+def init_engine(settings):
+    return SummariesDspyChatEngine(settings)
+
+
+## LLM Client classes for (Question) Decomposer and (Guru Card) Summarizer used by the chat engine.
+##   DSPy LLM clients require different handling than non-DSPy clients.
+##   Also non-DSPy clients are using the prompt generated (but not yet optimized) by DSPy.
+
+
+class DecomposerDspyClient:
+    def __init__(self, prompts, settings):
+        self.prompts = prompts
+
+        if os.environ.get("DSP_CACHEBOOL").lower() != "false":
+            logger.warning("DSP_CACHEBOOL should be set to True to get different responses for retry attempts")
+
+        if "predictor" not in settings:
+            settings["predictor"] = self.decomposer_predictor
+        self.decomposer_client = engines.create_llm_client(settings)
+
+    def decomposer_predictor(self, message):
+        prediction = self.prompts.decomposer(question=message)
+        derived_questions = json.loads(prediction.answer)
+        if "Answer" in derived_questions:
+            # For OpenAI 'gpt-4-turbo' in json mode
+            derived_questions = derived_questions["Answer"]
+        return derived_questions
+
+    def generate_derived_questions(self, query):
+        # generate_reponse() indirectly calls decomposer_predictor()
+        return self.decomposer_client.generate_reponse(query)
+
+
+class DecomposerLlmClient:
+    def __init__(self, prompts, settings):
+        self.prompts = prompts
+        self.decomposer_client = engines.create_llm_client(settings)
+
+    def generate_derived_questions(self, query):
+        response = call_llm(self.decomposer_client, self.prompts.decomposer, question=query)
+        return json.loads(response)
+
+
+class SummarizerDspyClient:
+    def __init__(self, prompts, settings):
+        self.prompts = prompts
+
+        settings["predictor"] = None
+        self.summarizer_client = engines.create_llm_client(settings)
+
+    def summarizer(self, **kwargs):
+        with dspy.context(lm=self.summarizer_client.llm):
+            return self.prompts.summarizer(**kwargs).answer
+
+
+class SummarizerLlmClient:
+    def __init__(self, prompts, settings):
+        self.prompts = prompts
+
+        self.summarizer_client = engines.create_llm_client(settings)
+
+    def summarizer(self, **kwargs):
+        return call_llm(self.summarizer_client, self.prompts.summarizer, **kwargs)
+
+
+def call_llm(llm_client, dspy_predict_obj: dspy.Predict, **template_inputs):
+    template = signature_to_template(dspy_predict_obj.signature)
+    # demos are for in-context learning
+    dspy_prompt = template({"demos": []} | template_inputs)
+    logger.debug("Prompt: %s", dspy_prompt)
+    response = llm_client.generate_reponse(dspy_prompt)
+    logger.debug("Response object: %s", response)
+    return response
+
+
+class Prompts:
+    @cached_property
+    def decomposer(self):
+        class DecomposeQuestion(dspy.Signature):
+            """Rephrase and decompose into multiple questions so that we can search for relevant public benefits eligibility requirements. \
+    Be concise -- only respond with JSON. Only output the questions as a JSON list: ["question1", "question2", ...]. \
+    The question is: {question}"""
+
+            # TODO: Incorporate https://gist.github.com/hugodutka/6ef19e197feec9e4ce42c3b6994a919d
+
+            question = dspy.InputField()
+            answer = dspy.OutputField(desc='["question1", "question2", ...]')
+
+        return dspy.Predict(DecomposeQuestion)
+
+    @cached_property
+    def summarizer(self):
+        class SummarizeCardGivenQuestion(dspy.Signature):
+            """Summarize the following context into 1 sentence without explicitly answering the question(s): {context_question}
+
+            Context: {context}
+            """
+
+            context_question = dspy.InputField()
+            context = dspy.InputField()
+            answer = dspy.OutputField()
+
+        return dspy.Predict(SummarizeCardGivenQuestion)
+
+
+## Summaries (using DSPy) Chat Engine
+
+
+class SummariesDspyChatEngine:
+    def __init__(self, orig_settings):
+        # Make a copy of the settings so that we can modify them
+        self.settings = orig_settings.copy()
+
+        # Use the same vector DB configuration as ingest-guru-cards.py
+        self.vectordb_wrapper = vector_db.ingest_vectordb_wrapper
+        self.retrieve_k = int(self.settings.pop("retrieve_k"))
+
+        # TODO: ingestigate if this should be set to true
+        os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+        prompts = Prompts()
+        if self.settings["model"].startswith("dspy ::"):
+            self.decomposer_client = DecomposerDspyClient(prompts, self.settings.copy())
+        else:
+            self.decomposer_client = DecomposerLlmClient(prompts, self.settings.copy())
+
+        if "model2" in self.settings:
+            self.settings["model"] = self.settings.pop("model2")
+        if "temperature2" in self.settings:
+            self.settings["temperature"] = self.settings.pop("temperature2")
+        if self.settings["model"].startswith("dspy ::"):
+            self.summarizer_client = SummarizerDspyClient(prompts, self.settings.copy())
+        else:
+            self.summarizer_client = SummarizerLlmClient(prompts, self.settings.copy())
+
+        # TODO for scalability: replace with DB lookup
+        self.guru_card_texts = guru_cards.GuruCardsProcessor().extract_qa_text_from_guru()
+
+    @utils.timer
+    def gen_response(self, query):
+        gen_results = GenerationResults(query)
+
+        for i in range(3):  # retry loop
+            if i > 0:
+                logger.warning("Retrying to get parsable JSON response -- attempt %i", i)
+                # TODO: also send notification to UI by adding a message to GenerationResults
+            try:
+                derived_questions = self.decomposer_client.generate_derived_questions(query)
+                logger.info("Derived questions: %s", derived_questions)
+                break  # exit retry loop
+            except json.JSONDecodeError as e:
+                logger.error("Error decomposing question: %s", e)
+                derived_questions = []
+
+        collect_retrieved_cards(derived_questions, self.vectordb_wrapper.vectordb, self.retrieve_k, gen_results)
+        logger.debug("gen_results: %s", gen_results)
+
+        populate_summaries(gen_results, self.guru_card_texts, self.summarizer_client.summarizer)
+        return gen_results

--- a/05-assistive-chatbot/chatbot/engines/v2_household_engine.py
+++ b/05-assistive-chatbot/chatbot/engines/v2_household_engine.py
@@ -1,11 +1,12 @@
 import json
 import logging
 import os
-from functools import cached_property
 from dataclasses import dataclass
+from functools import cached_property
 from typing import List, Optional
 
 import dspy  # type: ignore[import-untyped]
+from dspy.signatures.signature import signature_to_template  # type: ignore[import-untyped]
 
 from chatbot import engines, guru_cards, utils, vector_db
 
@@ -54,92 +55,79 @@ class SummariesChatEngine:
         # Make a copy of the settings so that we can modify them
         self.settings = orig_settings.copy()
 
-        assert self.settings["model"].startswith("dspy ::"), f"Expecting DSPy LLM but got: {self.settings['model']}"
-
         # Use the same vector DB configuration as ingest-guru-cards.py
         self.vectordb_wrapper = vector_db.ingest_vectordb_wrapper
         self.retrieve_k = int(self.settings.pop("retrieve_k"))
 
-        if "predictor" not in self.settings:
-            self.settings["predictor"] = self.decomposer_predictor
-        logger.info("Creating DecomposeQuestion LLM client with %s", self.settings)
-        self.decomposer_client = engines.create_llm_client(self.settings)
-
-        self.settings["predictor"] = None
-        logger.info("Creating Summarize LLM client with %s", self.settings)
-        self.summarizer_client = engines.create_llm_client(self.settings)
-
         # TODO: ingestigate if this should be set to true
         os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+        if self.settings["model"].startswith("dspy ::"):
+            if os.environ.get("DSP_CACHEBOOL").lower() != "false":
+                logger.warning("DSP_CACHEBOOL should be set to True to get different responses for retry attempts")
+
+            if "predictor" not in self.settings:
+                self.settings["predictor"] = self.decomposer_predictor
+            logger.info("Creating DecomposeQuestion LLM client with %s", self.settings)
+            self.decomposer_client = engines.create_llm_client(self.settings)
+
+            self.settings["predictor"] = None
+            logger.info("Creating Summarize LLM client with %s", self.settings)
+            self.summarizer_client = engines.create_llm_client(self.settings)
+        else:
+            self.llm_client = engines.create_llm_client(self.settings)
 
         self.guru_card_texts = guru_cards.GuruCardsProcessor().extract_qa_text_from_guru()
 
     def decomposer_predictor(self, message):
         logger.info("Decomposing: %s", message)
         prediction = self.decomposer(question=message)
-        return json.loads(prediction.answer)
-
-    use_dspy_client = True
+        derived_questions = json.loads(prediction.answer)
+        if "Answer" in derived_questions:
+            # For OpenAI 'gpt-4-turbo' in json mode
+            derived_questions = derived_questions["Answer"]
+        return derived_questions
 
     @utils.timer
     def gen_response(self, query):
         gen_results = GenerationResults(query)
 
-        if self.use_dspy_client:
-            derived_questions = self.decomposer_client.generate_reponse(query)
-        else:
-            with dspy.context(lm=self.decomposer_client.llm):
-                derived_questions = self.generate_derived_questions(query)
-        logger.info("Derived questions: %s", derived_questions)
+        for i in range(3):  # retry loop
+            if i > 0:
+                logger.warning("Retrying to get parsable JSON response -- attempt %i", i)
+                # TODO: also send notification to UI by adding a message to GenerationResults
+            try:
+                if hasattr(self, "decomposer_client"):
+                    derived_questions = self.decomposer_client.generate_reponse(query)
+                else:
+                    response = self.call_llm_client(self.decomposer, question=query)
+                    derived_questions = json.loads(response)
+                logger.info("Derived questions: %s", derived_questions)
+                break  # out of for-loop
+            except json.JSONDecodeError as e:
+                logger.error("Error decomposing question: %s", e)
+                derived_questions = []
 
-        self.collect_retrieved_cards(derived_questions, gen_results)
+        collect_retrieved_cards(derived_questions, self.vectordb_wrapper.vectordb, self.retrieve_k, gen_results)
         logger.info("gen_results: %s", gen_results)
 
-        if self.use_dspy_client:
+        if hasattr(self, "summarizer_client"):
             with dspy.context(lm=self.summarizer_client.llm):
-                summarizer_lambda = lambda **kwargs: self.summarizer(**kwargs)
-                create_summaries(gen_results, summarizer_lambda, self.guru_card_texts)
+                create_summaries(gen_results, self.guru_card_texts, lambda **kwargs: self.summarizer(**kwargs).answer)
         else:
-            with dspy.context(lm=self.summarizer_client.llm):
-                create_summaries(gen_results, self.summarizer, self.guru_card_texts)
+            create_summaries(
+                gen_results, self.guru_card_texts, lambda **kwargs: self.call_llm_client(self.summarizer, **kwargs)
+            )
 
         return gen_results
 
-    def generate_derived_questions(self, question):
-        logger.info("Decomposing: %s", question)
-        pred = self.decomposer(question=question)
-        # if CALL_OPENAI_DIRECTLY:  # debugging difference between using OpenAI via DSPy
-        #     # print("pred", pred)
-        #     call_openai_directly(question)
-        logger.info("Answer: %s", pred.answer)
-        try:
-            derived_questions = json.loads(pred.answer)
-        except Exception as e:  # in case LLM doesn't generate valid JSON
-            print("!!! Error:", e)
-            # traceback.print_exc()
-            # # retry using direct call to OpenAI since DSPy caches responses and hence will return the same response
-            # for i in range(3):
-            #     print("Retrying by calling OpenAI directly")
-            #     # TODO: also send notification to UI by adding a message to GenerationResults
-            #     response = call_openai_directly(question)
-            #     try:
-            #         derived_questions = json.loads(response)
-            #         break  # out of for-loop
-            #     except Exception as e2:
-            #         print("!!!! Error:", e2)
-            #         traceback.print_exc()
-
-        if "Answer" in derived_questions:
-            # For OpenAI 'gpt-4-turbo' in json mode
-            derived_questions = derived_questions["Answer"]
-        print("  => ", derived_questions)
-        return derived_questions
-
-    def collect_retrieved_cards(self, derived_qs, gen_results):
-        logger.debug("RETRIEVE_K: %i", self.retrieve_k)
-        gen_results.derived_questions = retrieve_cards(derived_qs, self.vectordb_wrapper.vectordb, self.retrieve_k)
-        gen_results.cards = collate_by_card_score_sum(gen_results.derived_questions)
-
+    def call_llm_client(self, predict, **template_inputs):
+        template = signature_to_template(predict.signature)
+        dspy_prompt = template({"demos": []} | template_inputs)
+        logger.info("DSPy prompt: %s", dspy_prompt)
+        response = self.llm_client.generate_reponse(dspy_prompt)
+        logger.info("OpenAI response object: %s", response)
+        return response
 
     @cached_property
     def decomposer(self):
@@ -168,6 +156,13 @@ class SummariesChatEngine:
             answer = dspy.OutputField()
 
         return dspy.Predict(SummarizeCardGivenQuestion)
+
+
+def collect_retrieved_cards(derived_qs, vectordb, retrieve_k, gen_results):
+    logger.debug("RETRIEVE_K: %i", retrieve_k)
+    gen_results.derived_questions = retrieve_cards(derived_qs, vectordb, retrieve_k)
+    gen_results.cards = collate_by_card_score_sum(gen_results.derived_questions)
+
 
 def collate_by_card_score_sum(derived_question_entries):
     all_retrieved_cards = dict()
@@ -204,6 +199,7 @@ def collate_by_card_score_sum(derived_question_entries):
         for card, score in all_retrieved_cards.items()
     ]
 
+
 def retrieve_cards(derived_qs, vectordb, retrieve_k=5):
     results = []  # list of DerivedQuestionEntry
     # print(f"Processing user question {qa_dict['id']}: with {len(derived_qs)} derived questions")
@@ -216,7 +212,8 @@ def retrieve_cards(derived_qs, vectordb, retrieve_k=5):
         results.append(DerivedQuestionEntry(q, retrieved_cards, retrieved_chunks, scores))
     return results
 
-def create_summaries(gen_results, summarizer, guru_card_texts):
+
+def create_summaries(gen_results, guru_card_texts, summarizer):
     logger.info("Summarizing %i retrieved cards...", len(gen_results.cards))
     for i, card_entry in enumerate(gen_results.cards):
         # Limit summarizing of Guru cards based on score and card count
@@ -228,6 +225,4 @@ def create_summaries(gen_results, summarizer, guru_card_texts):
         # Using only the original question causes the LLM to try to answer the question.
         context_questions = " ".join(card_entry.associated_derived_qs + [gen_results.question])
         logger.info("  %i. Summarizing: %s", i, card_entry.card_title)
-        prediction = summarizer(context_question=context_questions, context=card_entry.entire_text)
-        card_entry.summary = prediction.answer
-
+        card_entry.summary = summarizer(context_question=context_questions, context=card_entry.entire_text)

--- a/05-assistive-chatbot/chatbot/engines/v2_household_engine.py
+++ b/05-assistive-chatbot/chatbot/engines/v2_household_engine.py
@@ -63,7 +63,7 @@ class SummariesChatEngine:
         self.vectordb_wrapper = vector_db.ingest_vectordb_wrapper
         self.retrieve_k = int(settings.pop("retrieve_k"))
 
-        # TODO: ingestigate if this should be set to true
+        # TODO: investigate if this should be set to true
         os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
         self._init_llms(settings.copy())

--- a/05-assistive-chatbot/chatbot/engines/v2_household_engine.py
+++ b/05-assistive-chatbot/chatbot/engines/v2_household_engine.py
@@ -1,7 +1,11 @@
+import dataclasses
+import json
 import logging
 import os
+from dataclasses import dataclass
+from typing import List
 
-import dspy
+import dspy  # type: ignore[import-untyped]
 
 from chatbot import engines, utils
 
@@ -20,26 +24,140 @@ def init_engine(settings):
     return SummariesChatEngine(settings)
 
 
+@dataclass
+class CardResponseEntry:
+    card_title: str
+    associated_derived_qs: List[str]
+    score_sum: float
+    quotes: List[str]
+    summary: str = None
+    entire_text: str = None
+
+
+@dataclass
+class DerivedQuestionEntry:
+    derived_question: str
+    retrieved_cards: List[str] = None
+    retrieved_chunks: List[str] = None
+    retrieval_scores: List[float] = None
+
+
+@dataclass
+class GenerationResults:
+    question: str
+    derived_questions: List[DerivedQuestionEntry] = None
+    cards: List[CardResponseEntry] = None
+
+
 class SummariesChatEngine:
     def __init__(self, settings):
         self.settings = settings
-        self.summarizer = create_summarizer()
-        if "predictor" not in settings:
-            settings["predictor"] = self.summarizer_predictor
-        logger.info("Creating LLM client with %s", settings)
-        self.client = engines.create_llm_client(settings)
 
-    def summarizer_predictor(self, message):
-        # logger.info("Summarizing: %s using %s", message, summarizer)
-        prediction = self.summarizer(context_question=message, context="")
+        self.decomposer = create_question_decomposer()
+        if "predictor" not in settings:
+            settings["predictor"] = self.decomposer_predictor
+        logger.info("Creating DecomposeQuestion LLM client with %s", settings)
+        self.decomposer_client = engines.create_llm_client(settings)
+
+        self.summarizer = create_summarizer()
+        settings["predictor"] = None
+        logger.info("Creating Summarize LLM client with %s", settings)
+        self.summarizer_client = engines.create_llm_client(settings)
+
+    def decomposer_predictor(self, message):
+        logger.info("Decomposing: %s", message)
+        prediction = self.decomposer(question=message)
         return prediction.answer
 
     @utils.timer
     def gen_response(self, query):
-        response = self.client.generate_reponse(query)
-        # TODO: decompose query
-        # TODO: create summaries
-        return response
+        gen_results = GenerationResults(query)
+
+        # derived_questions = self.decomposer_client.generate_reponse(query)
+        with dspy.context(lm=self.decomposer_client.llm):
+            derived_questions = self.generate_derived_questions(query)
+        logger.info("Derived questions: %s", derived_questions)
+
+        self.collect_retrieved_cards(derived_questions, gen_results)
+        logger.info("gen_results: %s", gen_results)
+
+        with dspy.context(lm=self.summarizer_client.llm):
+            self.create_summaries(gen_results, self.summarizer, self.get_guru_card_texts())
+
+        return json.dumps(dataclasses.asdict(gen_results), indent=2)
+
+    def generate_derived_questions(self, question):
+        logger.info("Decomposing: %s", question)
+        pred = self.decomposer(question=question)
+        # if CALL_OPENAI_DIRECTLY:  # debugging difference between using OpenAI via DSPy
+        #     # print("pred", pred)
+        #     call_openai_directly(question)
+        logger.info("Answer: %s", pred.answer)
+        try:
+            derived_questions = json.loads(pred.answer)
+        except Exception as e:  # in case LLM doesn't generate valid JSON
+            print("!!! Error:", e)
+            # traceback.print_exc()
+            # # retry using direct call to OpenAI since DSPy caches responses and hence will return the same response
+            # for i in range(3):
+            #     print("Retrying by calling OpenAI directly")
+            #     # TODO: also send notification to UI by adding a message to GenerationResults
+            #     response = call_openai_directly(question)
+            #     try:
+            #         derived_questions = json.loads(response)
+            #         break  # out of for-loop
+            #     except Exception as e2:
+            #         print("!!!! Error:", e2)
+            #         traceback.print_exc()
+
+        if "Answer" in derived_questions:
+            # For OpenAI 'gpt-4-turbo' in json mode
+            derived_questions = derived_questions["Answer"]
+        print("  => ", derived_questions)
+        return derived_questions
+
+    def collect_retrieved_cards(self, derived_qs, gen_results):
+        # retrieve_k = settings["retrieve_k"]
+        # print("RETRIEVE_K:", retrieve_k)
+        # gen_results.derived_questions = retrieve_cards(derived_qs, get_vectordb(), retrieve_k)
+        # gen_results.cards = collate_by_card_score_sum(gen_results.derived_questions)
+        gen_results.cards = [CardResponseEntry("A", ["B"], 0.5, ["C"])]
+
+    def get_guru_card_texts(self):
+        # if settings["guru_card_texts"] is None:
+        #     # Extract Guru card texts so it can be summarized
+        #     settings["guru_card_texts"] = ingest.extract_qa_text_from_guru()
+        # return settings["guru_card_texts"]
+        return {"A": "B", "C": "D"}
+
+    def create_summaries(self, gen_results, summarizer, guru_card_texts):
+        logger.info("Summarizing %i retrieved cards...", len(gen_results.cards))
+        for i, card_entry in enumerate(gen_results.cards):
+            # Limit summarizing of Guru cards based on score and card count
+            if i > 2 and card_entry.score_sum < 0.3:
+                continue
+            card_text = guru_card_texts[card_entry.card_title]
+            card_entry.entire_text = "\n".join([card_entry.card_title, card_text])
+            # Summarize based on derived question and original question
+            # Using only the original question causes the LLM to try to answer the question.
+            context_questions = " ".join(card_entry.associated_derived_qs + [gen_results.question])
+            logger.info("  %i. Summarizing: %s", i, card_entry.card_title)
+            prediction = summarizer(context_question=context_questions, context=card_entry.entire_text)
+            card_entry.summary = prediction.answer
+
+
+def create_question_decomposer():
+    class DecomposeQuestion(dspy.Signature):
+        """Rephrase and decompose into multiple questions so that we can search for relevant public benefits eligibility requirements. \
+Be concise -- only respond with JSON. Only output the questions as a JSON list: ["question1", "question2", ...]. \
+The question is: {question}"""
+
+        # TODO: Incorporate https://gist.github.com/hugodutka/6ef19e197feec9e4ce42c3b6994a919d
+
+        question = dspy.InputField()
+        answer = dspy.OutputField(desc='["question1", "question2", ...]')
+
+    return dspy.Predict(DecomposeQuestion)
 
 
 def create_summarizer():

--- a/05-assistive-chatbot/chatbot/llms/__init__.py
+++ b/05-assistive-chatbot/chatbot/llms/__init__.py
@@ -37,10 +37,7 @@ def qualified_llm_name(client_name, model_name):
     return f"{client_name} :: {model_name}"
 
 
-def ignore(module_name):
-    # if module_name.startswith("dspy ::"):
-    #     # DSPy client code is not yet ready for use
-    #     return True
+def ignore(_module_name):
     return False
 
 

--- a/05-assistive-chatbot/chatbot/llms/anthopic_client.py
+++ b/05-assistive-chatbot/chatbot/llms/anthopic_client.py
@@ -1,4 +1,9 @@
+import logging
+import os
+
 from anthopic import Anthropic
+
+logger = logging.getLogger(__name__)
 
 CLIENT_NAME = "anthropic"
 # These names will be associated with this Python module
@@ -12,9 +17,12 @@ def init_client(model_name, settings):
 class AnthropicLlmClient:
     def __init__(self, model_name, settings):
         self.model_name = model_name
-        self.settings = settings
-        self.max_tokens = settings.get("max_tokens", 1024)
+        self.settings = {
+            # MAX TOKENS for response
+            "max_tokens": int(os.environ.get("MAX_TOKENS", 1024)),
+        } | settings
 
+        logger.info("Creating LLM client '%s' with %s", model_name, self.settings)
         # ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
         self.client = Anthropic(
             # api_key=ANTHROPIC_API_KEY,
@@ -23,7 +31,7 @@ class AnthropicLlmClient:
     def generate_reponse(self, message):
         generated_response = self.client.messages.create(
             model=self.model_name,
-            max_tokens=self.max_tokens,
+            max_tokens=self.settings["max_tokens"],
             messages=[{"role": "user", "content": message}],
         )
         text_response = "\n".join([text_block.text for text_block in generated_response.content])

--- a/05-assistive-chatbot/chatbot/llms/dspy_client.py
+++ b/05-assistive-chatbot/chatbot/llms/dspy_client.py
@@ -23,10 +23,10 @@ class DspyLlmClient:
     def __init__(self, model_name, settings):
         self.model_name = model_name
         self.predictor = settings.pop("predictor")
-        self.llm = self._create_llm_model(model_name, **settings)
+        self.llm = self._create_llm_model(settings)
         logger.info("DspyLlmClient: %s", settings)
 
-    def _create_llm_model(self, respond_with_json=False, **settings):
+    def _create_llm_model(self, settings):
         dspy_llm_kwargs = {
             # The default DSPy max_tokens is only 150, which caused issues due to incomplete JSON string output
             "max_tokens": 1000,
@@ -36,7 +36,8 @@ class DspyLlmClient:
             return dspy.OllamaLocal(model=self.model_name, **dspy_llm_kwargs)
             # Alternative is using OpenAI-compatible API: https://gist.github.com/jrknox1977/78c17e492b5a75ee5bbaf9673aee4641
         elif self.model_name in _OPENAI_LLMS:
-            if respond_with_json:
+            if settings.get("respond_with_json", False):
+                assert False
                 return dspy.OpenAI(model=self.model_name, **dspy_llm_kwargs, response_format={"type": "json_object"})
             else:
                 return dspy.OpenAI(model=self.model_name, **dspy_llm_kwargs)

--- a/05-assistive-chatbot/chatbot/llms/dspy_client.py
+++ b/05-assistive-chatbot/chatbot/llms/dspy_client.py
@@ -22,32 +22,31 @@ def init_client(model_name, settings):
 class DspyLlmClient:
     def __init__(self, model_name, settings):
         self.model_name = model_name
-        self.predictor = settings.pop("predictor")
-        self.llm = self._create_llm_model(settings)
-        logger.info("DspyLlmClient: %s", settings)
-
-    def _create_llm_model(self, settings):
         dspy_llm_kwargs = {
             # The default DSPy max_tokens is only 150, which caused issues due to incomplete JSON string output
-            "max_tokens": 1000,
+            "max_tokens": int(os.environ.get("MAX_TOKENS", 1000)),
         } | settings
-        logger.debug("Creating LLM model: %s with args: %s", self.model_name, dspy_llm_kwargs)
+        logger.info("Creating LLM client '%s' with: %s", self.model_name, dspy_llm_kwargs)
+
+        self.predictor = settings.pop("predictor")
+        self.llm = self._create_llm_model(settings)
+
+    def _create_llm_model(self, settings):
         if self.model_name in _OLLAMA_LLMS:
-            return dspy.OllamaLocal(model=self.model_name, **dspy_llm_kwargs)
+            return dspy.OllamaLocal(model=self.model_name, **settings)
             # Alternative is using OpenAI-compatible API: https://gist.github.com/jrknox1977/78c17e492b5a75ee5bbaf9673aee4641
-        elif self.model_name in _OPENAI_LLMS:
+        if self.model_name in _OPENAI_LLMS:
             if settings.get("respond_with_json", False):
-                assert False
-                return dspy.OpenAI(model=self.model_name, **dspy_llm_kwargs, response_format={"type": "json_object"})
-            else:
-                return dspy.OpenAI(model=self.model_name, **dspy_llm_kwargs)
-        elif self.model_name in _GOOGLE_LLMS:
-            return dspy.Google(model=f"models/{self.model_name}", **dspy_llm_kwargs)
-        elif self.model_name in _GROQ_LLMS:
+                return dspy.OpenAI(model=self.model_name, **settings, response_format={"type": "json_object"})
+
+            return dspy.OpenAI(model=self.model_name, **settings)
+        if self.model_name in _GOOGLE_LLMS:
+            return dspy.Google(model=f"models/{self.model_name}", **settings)
+        if self.model_name in _GROQ_LLMS:
             api_key = os.environ.get("GROQ_API_KEY")
-            return dspy.GROQ(api_key, model=self.model_name, **dspy_llm_kwargs)
-        else:
-            assert False, f"Unknown LLM model: {self.model_name}"
+            return dspy.GROQ(api_key, model=self.model_name, **settings)
+
+        assert False, f"Unknown LLM model: {self.model_name}"
 
     def generate_reponse(self, message):
         with dspy.context(lm=self.llm):

--- a/05-assistive-chatbot/chatbot/llms/google_gemini_client.py
+++ b/05-assistive-chatbot/chatbot/llms/google_gemini_client.py
@@ -1,6 +1,9 @@
+import logging
 import os
 
 import google.generativeai as genai
+
+logger = logging.getLogger(__name__)
 
 CLIENT_NAME = "google"
 MODEL_NAMES = ["gemini-pro", "gemini-1.5-pro", "gemini-1.5-flash"]
@@ -18,6 +21,7 @@ def init_client(model_name, settings):
 
 class GeminiLlmClient:
     def __init__(self, model_name, settings):
+        logger.info("Creating LLM client '%s' with %s", model_name, settings)
         if settings is not None:
             genai.GenerationConfig(**settings)
         self.client = genai.GenerativeModel(model_name)

--- a/05-assistive-chatbot/chatbot/llms/groq_client.py
+++ b/05-assistive-chatbot/chatbot/llms/groq_client.py
@@ -1,6 +1,9 @@
+import logging
 import os
 
 from groq import Groq
+
+logger = logging.getLogger(__name__)
 
 CLIENT_NAME = "groq"
 MODEL_NAMES = ["llama3-70b-8192", "mixtral-8x7b-32768"]
@@ -17,14 +20,15 @@ def init_client(model_name, settings):
 
 
 class GroqClient:
-    def __init__(self, model_name, _settings):
+    def __init__(self, model_name, settings):
         self.model_name = model_name
-        self.client = Groq()
+        self.settings = settings
+        logger.info("Creating LLM client '%s' with %s", model_name, self.settings)
+        self.client = Groq(**self.settings)
 
     def generate_reponse(self, message):
         chat_completion = self.client.chat.completions.create(
-            messages=[{"role": "user", "content": message}],
-            model=self.model_name,
+            messages=[{"role": "user", "content": message}], model=self.model_name, **self.settings
         )
 
         return chat_completion.choices[0].message.content

--- a/05-assistive-chatbot/chatbot/llms/langchain_google_client.py
+++ b/05-assistive-chatbot/chatbot/llms/langchain_google_client.py
@@ -1,4 +1,8 @@
+import logging
+
 from langchain_google_genai import ChatGoogleGenerativeAI
+
+logger = logging.getLogger(__name__)
 
 CLIENT_NAME = "langchain.google"
 MODEL_NAMES = ["gemini-pro", "gemini-1.5-pro", "gemini-1.5-flash"]
@@ -10,7 +14,9 @@ def init_client(model_name, settings):
 
 class LangchainGoogleClient:
     def __init__(self, model_name, settings):
-        self.client = ChatGoogleGenerativeAI(model=model_name, **settings)
+        self.settings = settings
+        logger.info("Creating LLM client '%s' with %s", model_name, self.settings)
+        self.client = ChatGoogleGenerativeAI(model=model_name, **self.settings)
 
     def generate_reponse(self, message):
         # invoke() returns langchain_core.messages.ai.AIMessage

--- a/05-assistive-chatbot/chatbot/llms/langchain_ollama_client.py
+++ b/05-assistive-chatbot/chatbot/llms/langchain_ollama_client.py
@@ -1,4 +1,8 @@
+import logging
+
 from langchain_community.llms.ollama import Ollama
+
+logger = logging.getLogger(__name__)
 
 CLIENT_NAME = "langchain.ollama"
 MODEL_NAMES = ["openhermes", "llama2", "mistral"]
@@ -10,6 +14,7 @@ def init_client(model_name, settings):
 
 class LangchainOllamaClient:
     def __init__(self, model_name, settings):
+        self.settings = settings
         # if not settings:
         #     settings = {
         #         # "system": "",
@@ -17,7 +22,8 @@ class LangchainOllamaClient:
         #         # See https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/llms/ollama.py
         #         "stop": None
         #     }
-        self.client = Ollama(model=model_name, **settings)
+        logger.info("Creating LLM client '%s' with %s", model_name, self.settings)
+        self.client = Ollama(model=model_name, **self.settings)
 
     def generate_reponse(self, message):
         return self.client.invoke(message)

--- a/05-assistive-chatbot/chatbot/llms/mock_llm_client.py
+++ b/05-assistive-chatbot/chatbot/llms/mock_llm_client.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 CLIENT_NAME = "mock"
 MODEL_NAMES = ["llm"]
 
@@ -10,7 +14,7 @@ class MockLlmClient:
     "Mock client that returns the mock_responses or the message itself."
 
     def __init__(self, model_name, settings):
-        self.model_name = model_name
+        logger.info("Creating Mock LLM client '%s' with %s", model_name, settings)
         self.mock_responses = settings
 
     def generate_reponse(self, message):

--- a/05-assistive-chatbot/chatbot/llms/openai_client.py
+++ b/05-assistive-chatbot/chatbot/llms/openai_client.py
@@ -31,12 +31,14 @@ class OpenaiLlmClient:
             response = self.client.chat.completions.create(
                 model=self.model_name,
                 messages=[{"role": "user", "content": message}],
+                **self.settings
             )
             return response.choices[0].message.content
         elif self.model_name in _LEGACY_MODELS:
             response = self.client.completions.create(
                 model=self.model_name,
                 prompt=message,
+                **self.settings
             )
             return response.choices[0].text
         else:

--- a/05-assistive-chatbot/chatbot/llms/openai_client.py
+++ b/05-assistive-chatbot/chatbot/llms/openai_client.py
@@ -1,6 +1,9 @@
+import logging
 import os
 
 from openai import OpenAI
+
+logger = logging.getLogger(__name__)
 
 CLIENT_NAME = "openai"
 
@@ -23,23 +26,21 @@ def init_client(model_name, settings):
 class OpenaiLlmClient:
     def __init__(self, model_name, settings):
         self.model_name = model_name
-        self.settings = settings
+        self.settings = {
+            # MAX TOKENS for response
+            "max_tokens": int(os.environ.get("MAX_TOKENS", 1000)),
+        } | settings
+        logger.info("Creating LLM client '%s' with %s", model_name, self.settings)
         self.client = OpenAI()
 
     def generate_reponse(self, message):
         if self.model_name in _CHAT_MODELS:
             response = self.client.chat.completions.create(
-                model=self.model_name,
-                messages=[{"role": "user", "content": message}],
-                **self.settings
+                model=self.model_name, messages=[{"role": "user", "content": message}], **self.settings
             )
             return response.choices[0].message.content
         elif self.model_name in _LEGACY_MODELS:
-            response = self.client.completions.create(
-                model=self.model_name,
-                prompt=message,
-                **self.settings
-            )
+            response = self.client.completions.create(model=self.model_name, prompt=message, **self.settings)
             return response.choices[0].text
         else:
             assert False, f"Unhandled LLM model: {self.model_name}"

--- a/05-assistive-chatbot/chatbot/vector_db.py
+++ b/05-assistive-chatbot/chatbot/vector_db.py
@@ -50,7 +50,7 @@ class LocalLangchainChromaVectorDb:
     @cached_property
     @utils.timer
     def vectordb(self):
-        logger.info("Creating Vector DB: %s", self.folder)
+        logger.info("Creating Vector DB client: %s", self.folder)
         return Chroma(
             embedding_function=self.embeddings_model,
             persist_directory=self.folder,

--- a/05-assistive-chatbot/chatbot/vector_db.py
+++ b/05-assistive-chatbot/chatbot/vector_db.py
@@ -1,0 +1,62 @@
+import logging
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Callable
+
+from langchain_community.embeddings import HuggingFaceEmbeddings, SentenceTransformerEmbeddings
+from langchain_community.vectorstores import Chroma
+
+from chatbot import utils
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EmbeddingsModel:
+    name: str
+    token_limit: int
+    create: Callable
+
+
+_EMBEDDINGS_MODEL_LIST = [
+    EmbeddingsModel("all-MiniLM-L6-v2", 256, lambda: SentenceTransformerEmbeddings(model_name="all-MiniLM-L6-v2")),
+    EmbeddingsModel("HuggingFace::all-MiniLM-L6-v2", 256, lambda: HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")),
+    EmbeddingsModel(
+        "BAAI/bge-small-en-v1.5", 512, lambda: SentenceTransformerEmbeddings(model_name="BAAI/bge-small-en-v1.5")
+    ),
+    EmbeddingsModel(
+        "mixedbread-ai/mxbai-embed-large-v1",
+        1024,
+        lambda: SentenceTransformerEmbeddings(model_name="mixedbread-ai/mxbai-embed-large-v1"),
+    ),
+    # EmbeddingsModel("Google::embedding-001", 2048, lambda: GoogleGenerativeAIEmbeddings(model="models/embedding-001")),
+    # EmbeddingsModel("Google::text-embedding-004", 768, lambda: GoogleGenerativeAIEmbeddings(model="models/text-embedding-004")),
+]
+
+EMBEDDING_MODELS = {model.name: model for model in _EMBEDDINGS_MODEL_LIST}
+
+
+class LocalLangchainChromaVectorDb:
+    def __init__(self, embedding_name="all-MiniLM-L6-v2", folder="./chroma_db"):
+        self.embedding_name = embedding_name
+        self.folder = folder
+
+    @cached_property
+    @utils.timer
+    def embeddings_model(self):
+        logger.info("Creating embeddings model: %s", self.embedding_name)
+        return EMBEDDING_MODELS[self.embedding_name].create()
+
+    @cached_property
+    @utils.timer
+    def vectordb(self):
+        logger.info("Creating Vector DB: %s", self.folder)
+        return Chroma(
+            embedding_function=self.embeddings_model,
+            persist_directory=self.folder,
+            # Must use collection_name="langchain" -- https://github.com/langchain-ai/langchain/issues/10864#issuecomment-1730303411
+            collection_name="langchain",
+        )
+
+
+ingest_vectordb_wrapper = LocalLangchainChromaVectorDb()

--- a/05-assistive-chatbot/chatbot_api.py
+++ b/05-assistive-chatbot/chatbot_api.py
@@ -7,8 +7,8 @@ an API that can be deployed with the Chainlit chatbot.
 """
 
 import logging
-
 from typing import Dict
+
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 

--- a/05-assistive-chatbot/cmdline.py
+++ b/05-assistive-chatbot/cmdline.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-
 """
 Commandline interface for running the same operations as the chatbot.
 Useful for development, debugging, and testing.
 """
 
+import dataclasses
+import json
 import logging
 
 import chatbot
+from chatbot.engines import v2_household_engine
 
 logger = logging.getLogger(f"chatbot.{__name__}")
 
@@ -23,7 +25,7 @@ message = "Hello, what's your name?"
 response = chat_engine.gen_response(message)
 
 # Check the response type in case the chat_engine returns a non-string object
-if not isinstance(response, str):
-    logger.error("Unexpected type: %s", type(response))
+if isinstance(response, v2_household_engine.GenerationResults):
+    response = json.dumps(dataclasses.asdict(response), indent=2)
 
 print(response)

--- a/05-assistive-chatbot/ingest-guru-cards.py
+++ b/05-assistive-chatbot/ingest-guru-cards.py
@@ -1,87 +1,35 @@
 #!/usr/bin/env python
 import logging
-from dataclasses import dataclass
-from functools import cached_property
-from typing import Callable
 
 import dotenv
 from langchain.docstore.document import Document
-from langchain_community.embeddings import HuggingFaceEmbeddings, SentenceTransformerEmbeddings
-from langchain_community.vectorstores import Chroma
 
 import chatbot
-from chatbot import guru_cards, utils
+from chatbot import guru_cards, vector_db
 from chatbot.ingest.text_splitter import TextSplitter
 
 logger = logging.getLogger(f"chatbot.{__name__}")
 
+dotenv.load_dotenv()
+chatbot.configure_logging()
 
-@dataclass
-class EmbeddingsModel:
-    name: str
-    token_limit: int
-    create: Callable
+vectordb_wrapper = vector_db.ingest_vectordb_wrapper
 
+text_splitter = TextSplitter(
+    embeddings_model=vectordb_wrapper.embeddings_model,
+    token_limit=vector_db.EMBEDDING_MODELS[vectordb_wrapper.embedding_name].token_limit,
+    text_splitter_name="RecursiveCharacterTextSplitter",
+    # Use smaller chunks for shorter-length quotes
+    chunk_size=250,
+    chunk_overlap=100,
+)
 
-_EMBEDDINGS_MODEL_LIST = [
-    EmbeddingsModel("all-MiniLM-L6-v2", 256, lambda: SentenceTransformerEmbeddings(model_name="all-MiniLM-L6-v2")),
-    EmbeddingsModel("HuggingFace::all-MiniLM-L6-v2", 256, lambda: HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")),
-    EmbeddingsModel(
-        "BAAI/bge-small-en-v1.5", 512, lambda: SentenceTransformerEmbeddings(model_name="BAAI/bge-small-en-v1.5")
-    ),
-    EmbeddingsModel(
-        "mixedbread-ai/mxbai-embed-large-v1",
-        1024,
-        lambda: SentenceTransformerEmbeddings(model_name="mixedbread-ai/mxbai-embed-large-v1"),
-    ),
-    # EmbeddingsModel("Google::embedding-001", 2048, lambda: GoogleGenerativeAIEmbeddings(model="models/embedding-001")),
-    # EmbeddingsModel("Google::text-embedding-004", 768, lambda: GoogleGenerativeAIEmbeddings(model="models/text-embedding-004")),
-]
-
-EMBEDDING_MODELS = {model.name: model for model in _EMBEDDINGS_MODEL_LIST}
-
-
-class AppState:
-    def __init__(self, embedding_name):
-        self.embedding_name = embedding_name
-        self.embeddings_model = EMBEDDING_MODELS[self.embedding_name].create()
-        logger.info("Embeddings model created: %s", self.embeddings_model)
-
-    @cached_property
-    @utils.timer
-    def vectordb(self):
-        logger.info("Creating Vector DB")
-        return Chroma(
-            embedding_function=self.embeddings_model,
-            # Must use collection_name="langchain" -- https://github.com/langchain-ai/langchain/issues/10864#issuecomment-1730303411
-            collection_name="langchain",
-            persist_directory="./chroma_db",
-        )
-
-
-if __name__ == "__main__":
-    dotenv.load_dotenv()
-    chatbot.configure_logging()
-
-    app_state = AppState("all-MiniLM-L6-v2")
-
-    text_splitter = TextSplitter(
-        embeddings_model=app_state.embeddings_model,
-        token_limit=EMBEDDING_MODELS[app_state.embedding_name].token_limit,
-        text_splitter_name="RecursiveCharacterTextSplitter",
-        # Use smaller chunks for shorter-length quotes
-        chunk_size=250,
-        chunk_overlap=100,
-    )
-
-    guru_cards_processor = guru_cards.GuruCardsProcessor()
-    guru_question_answers = guru_cards_processor.extract_qa_text_from_guru()
-    # Chunk the json data and load into vector db
-    for question, answer in guru_question_answers.items():
-        logger.info("Processing document: %s", question)
-        entire_text = question + "\n\n" + answer
-        chunks = text_splitter.split_into_chunks(entire_text)
-        docs = [
-            Document(page_content=t, metadata={"source": question.strip(), "entire_card": entire_text}) for t in chunks
-        ]
-        app_state.vectordb.add_documents(documents=docs)
+guru_cards_processor = guru_cards.GuruCardsProcessor()
+guru_question_answers = guru_cards_processor.extract_qa_text_from_guru()
+# Chunk the json data and load into vector db
+for question, answer in guru_question_answers.items():
+    logger.info("Processing document: %s", question)
+    entire_text = question + "\n\n" + answer
+    chunks = text_splitter.split_into_chunks(entire_text)
+    docs = [Document(page_content=t, metadata={"source": question.strip(), "entire_card": entire_text}) for t in chunks]
+    vectordb_wrapper.vectordb.add_documents(documents=docs)


### PR DESCRIPTION
## Ticket

Partly resolves https://navalabs.atlassian.net/browse/DST-218

## Changes

Populate prototype code in `05-assistive-chatbot` with the summarizing and quoting capabilities from `02-household-queries` chatbot.

Update handling `settings` for LLM clients and did some general refactoring.

## Context for reviewers

This provides baseline summarizing and quoting capabilities for the prototype.

## Testing

Testing instructions and expected behavior:
1. `pip install -r requirements.txt`
1. Update `.env`
2. To clear and populate the DB, run: `rm -rf chroma_db && ./ingest-guru-cards.py`
1. Try it on the command line, for example:
```
CHATBOT_LOG_LEVEL=INFO CHAT_ENGINE=Summaries    LLM_MODEL_NAME='openai :: gpt-3.5-turbo-instruct' LLM_MODEL_NAME_2='openai :: gpt-3.5-turbo-instruct' RETRIEVE_K=2 ./cmdline.py

CHATBOT_LOG_LEVEL=INFO CHAT_ENGINE=Summaries-DSPy LLM_MODEL_NAME='dspy :: gpt-3.5-turbo-instruct' LLM_MODEL_NAME_2='openai :: gpt-3.5-turbo-instruct' RETRIEVE_K=2 ./cmdline.py
```
1. Try it via the web app (To ensure summaries are generated correctly, pick `*instruct` model for both LLMs):
```
./chatbot-chainlit.py
```
   - Open a browser to http://localhost:8000/
   - Open the `Settings panel` by clicking on the icon to the left of the bottom text input field.
   - Choose "Summaries" as the `Chat Mode` (synonymous with `CHAT_ENGINE` for the `cmdline.py` app) and pick `openai :: gpt-3.5-turbo-instruct` as the `Primary LLM` and `LLM Model for summarizer`. Adjust the two `Temperature...` settings to play with the responses.
   - click `Confirm`
   - type in any question and see derived questions, Guru cards, their summaries, and quotes:
<img width="726" alt="image" src="https://github.com/navapbc/labs-gen-ai-experiments/assets/55255674/8442b515-3598-4a01-8887-e570cf01520b">

